### PR TITLE
fetch invite_link for the chat properly

### DIFF
--- a/server/bot.py
+++ b/server/bot.py
@@ -174,7 +174,7 @@ def invite(update, context):
     users = parse_mentions(update.message)
     if users["not_found"]:
         update.message.reply_text(f"Я не знаю {', '.join(map(lambda n: '@'+n, users['not_found']))} :C")
-    for un, uid in users['id'].items(): return_to_chat(update.effective_chat, un, uid)
+    for un, uid in users['id'].items(): return_to_chat(bot.get_chat(update.effective_chat.id), un, uid)
 
 
 def echo(update, context):


### PR DESCRIPTION
`chat.invite_link` can be null even if there is an existing invite link.
See [docs](https://python-telegram-bot.readthedocs.io/en/stable/telegram.chat.html#telegram.Chat.invite_link), `Returned only in telegram.Bot.get_chat()`.
So it's better to get the full chat object by directly calling the API rather than using the existing one.

Before:
![Screenshot_2021-05-10_01-58-57](https://user-images.githubusercontent.com/7394728/117593505-d9c5cf00-b133-11eb-9f1e-6caacdc6b75f.png)
After:
![Screenshot_2021-05-10_01-59-09](https://user-images.githubusercontent.com/7394728/117593513-e1857380-b133-11eb-8339-72b27a8606af.png)
