### PR TITLE
add batch_invite cmd

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -156,13 +156,14 @@ def remove_user(user_id):
 
 def return_to_chat(chat, un, uid):
     link = chat.invite_link
+    chat_name = chat.title
     if not link:
         bot.send_message(chat_id=chat.id,
                          text=f"В вашем чате нет пригласительной ссылки, верните @{un} вручную!")
     else:
         try:
             bot.send_message(chat_id=uid,
-                             text=f"Возвращайся обратно! {link}")
+                             text=f"Возвращайся обратно в {chat_name}! {link}")
         except:
             bot.send_message(chat_id=chat.id,
                              text=f"Не удалось отправить приглашение @{un}, пришлите вручную ссылку: f{link}")
@@ -176,6 +177,19 @@ def invite(update, context):
     if users["not_found"]:
         update.message.reply_text(f"Я не знаю {', '.join(map(lambda n: '@'+n, users['not_found']))} :C")
     for un, uid in users['id'].items(): return_to_chat(bot.get_chat(update.effective_chat.id), un, uid)
+
+
+def batch_invite(update, context):
+    compose_functionality_message(
+        check_functionality(update.effective_chat),
+        update.effective_chat)
+    users = parse_mentions(update.message)
+    if users["not_found"]:
+        update.message.reply_text(f"Я не знаю {', '.join(map(lambda n: '@'+n, users['not_found']))} :C")
+    for un, uid in users['id'].items():
+        print(db.get_user_groups(uid))
+        for group_id in db.get_user_groups(uid):
+            return_to_chat(bot.get_chat(group_id), un, uid)
 
 
 def echo(update, context):
@@ -237,6 +251,7 @@ dp.add_handler(CommandHandler('sos', sos_message))
 dp.add_handler(CommandHandler('hide', hide))
 dp.add_handler(MessageHandler(Filters.status_update.new_chat_members, new_users))
 dp.add_handler(CommandHandler('invite', invite))
+dp.add_handler(CommandHandler('batch_invite', batch_invite))
 dp.add_handler(CommandHandler('echo', echo))
 
 def main():

--- a/bot.py
+++ b/bot.py
@@ -187,7 +187,6 @@ def batch_invite(update, context):
     if users["not_found"]:
         update.message.reply_text(f"Я не знаю {', '.join(map(lambda n: '@'+n, users['not_found']))} :C")
     for un, uid in users['id'].items():
-        print(db.get_user_groups(uid))
         for group_id in db.get_user_groups(uid):
             return_to_chat(bot.get_chat(group_id), un, uid)
 


### PR DESCRIPTION
This works in a simple way -- as we already store the `groups` IDs in DB, we can pull them upon the call of `/batch_invite` and generate links for each chat in a way similar to `/invite`.

This works as follows:
![image](https://user-images.githubusercontent.com/7394728/196003578-6324ea28-d980-4e3f-ba93-1437c6d9cbb5.png)

Questions:
1) Do we want to merge the messages for the chats?
2) Do we want to surface more information about a chat (e.g. description/..)?
